### PR TITLE
feat: support both Fedora 37 and 38

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -22,7 +22,7 @@ jobs:
           - rocky8-ansible
           - debian11-ansible
           - debian10-ansible
-          - fedora-ansible
+          - fedora38-ansible
           - opensuse_tumbleweed-ansible
           - openwrt-ansible
           - oracle7-ansible

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -56,13 +56,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/alpine-ansible-latest.yml
+++ b/.github/workflows/alpine-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/amazon2-ansible-latest.yml
+++ b/.github/workflows/amazon2-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/amazon2023-ansible-latest.yml
+++ b/.github/workflows/amazon2023-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/arch-ansible-latest.yml
+++ b/.github/workflows/arch-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/centos7-ansible-latest.yml
+++ b/.github/workflows/centos7-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/centos8-ansible-latest.yml
+++ b/.github/workflows/centos8-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/centosstream8-ansible-latest.yml
+++ b/.github/workflows/centosstream8-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/centosstream9-ansible-latest.yml
+++ b/.github/workflows/centosstream9-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/debian10-ansible-latest.yml
+++ b/.github/workflows/debian10-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/debian11-ansible-latest.yml
+++ b/.github/workflows/debian11-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/fedora37-ansible-latest.yml
+++ b/.github/workflows/fedora37-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/fedora37-ansible-latest.yml
+++ b/.github/workflows/fedora37-ansible-latest.yml
@@ -1,11 +1,13 @@
-name: build-all
-
+name: fedora37-ansible-latest
 on:
   # yamllint disable-line rule:truthy
   workflow_dispatch:
-  schedule:
-    - cron: '10 2 * * 1'
-
+  push:
+    paths:
+      - 'fedora37-ansible-latest/**'
+  pull_request:
+    paths:
+      - 'fedora37-ansible-latest/**'
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -13,34 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         dockerimage:
-          - alpine-ansible
-          - amazon2-ansible
-          - amazon2023-ansible
-          - arch-ansible
-          - centos7-ansible
-          - centos8-ansible
-          - rocky8-ansible
-          - debian11-ansible
-          - debian10-ansible
           - fedora37-ansible
-          - fedora38-ansible
-          - opensuse_tumbleweed-ansible
-          - openwrt-ansible
-          - oracle7-ansible
-          - ubuntu1804-ansible
-          - ubuntu2004-ansible
-          - ubuntu2204-ansible
         platforms:
           - linux/amd64
-            # #- linux/arm64
-        exclude:
-          - dockerimage: oracle7-ansible
-            platforms: linux/arm64
-          - dockerimage: arch-ansible
-            platforms: linux/arm64
-          - dockerimage: centos7-ansible
-            platforms: linux/arm64
-
+          #- linux/arm64
     steps:
       -
         name: Checkout
@@ -79,12 +57,3 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest
           platforms: ${{ matrix.platforms }}
         if: github.ref == 'refs/heads/master'
-      -
-        name: Update repo description
-        uses: peter-evans/dockerhub-description@v2
-        if: github.repository == 'rndmh3ro/docker-ansible' && github.ref == 'refs/heads/master'
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}
-          short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/fedora38-ansible-latest.yml
+++ b/.github/workflows/fedora38-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/fedora38-ansible-latest.yml
+++ b/.github/workflows/fedora38-ansible-latest.yml
@@ -1,13 +1,13 @@
-name: fedora-ansible-latest
+name: fedora38-ansible-latest
 on:
   # yamllint disable-line rule:truthy
   workflow_dispatch:
   push:
     paths:
-      - 'fedora-ansible-latest/**'
+      - 'fedora38-ansible-latest/**'
   pull_request:
     paths:
-      - 'fedora-ansible-latest/**'
+      - 'fedora38-ansible-latest/**'
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         dockerimage:
-          - fedora-ansible
+          - fedora38-ansible
         platforms:
           - linux/amd64
           #- linux/arm64

--- a/.github/workflows/opensuse_tumbleweed-ansible-latest.yml
+++ b/.github/workflows/opensuse_tumbleweed-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/openwrt-ansible-latest.yml
+++ b/.github/workflows/openwrt-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/oracle7-ansible-latest.yml
+++ b/.github/workflows/oracle7-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/rocky8-ansible-latest.yml
+++ b/.github/workflows/rocky8-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/rocky9-ansible-latest.yml
+++ b/.github/workflows/rocky9-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/ubuntu1804-ansible-latest.yml
+++ b/.github/workflows/ubuntu1804-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/ubuntu2004-ansible-latest.yml
+++ b/.github/workflows/ubuntu2004-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           platforms: ${{ matrix.platforms }}
           load: true
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/ubuntu2204-ansible-latest.yml
+++ b/.github/workflows/ubuntu2204-ansible-latest.yml
@@ -34,13 +34,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          tags: docker-${{ matrix.dockerimage }}:test
           load: true
           platforms: ${{ matrix.platforms }}
       -
         name: Test
         run: |
-          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+          docker run --rm docker-${{ matrix.dockerimage }}:test
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ They are meant for testing purposes and are mainly used for [dev-sec](https://gi
 | [Amazon Linux][amazon]            | [docker-amazon-ansible-latest][]              | [rndmh3ro/docker-amazon-ansible-latest][]              |
 | [Amazon Linux 2][amazon]          | [docker-amazon2-ansible-latest][]             | [rndmh3ro/docker-amazon2-ansible-latest][]             |
 | [Amazon Linux 2023][amazon]       | [docker-amazon2023-ansible-latest][]          | [rndmh3ro/docker-amazon2023-ansible-latest][]          |
+| [Fedora 37][fedora]               | [docker-fedora37-ansible-latest][]            | [rndmh3ro/docker-fedora37-ansible-latest][]            |
 | [Fedora 38][fedora]               | [docker-fedora38-ansible-latest][]            | [rndmh3ro/docker-fedora38-ansible-latest][]            |
 | [OpenSuse Tumbleweed][tumbleweed] | [docker-opensuse_tumbleweed-ansible-latest][] | [rndmh3ro/docker-opensuse_tumbleweed-ansible-latest][] |
 | [Arch Linux][arch]                | [docker-arch-ansible-latest][]                | [rndmh3ro/docker-arch-ansible-latest][]                |
@@ -58,6 +59,7 @@ Sebastian Gumprich <github@gumpri.ch>
 [docker-alpine-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/alpine-ansible-latest/Dockerfile
 [docker-amazon2-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/amazon2-ansible-latest/Dockerfile
 [docker-amazon2023-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/amazon2023-ansible-latest/Dockerfile
+[docker-fedora37-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/fedora37-ansible-latest/Dockerfile
 [docker-fedora38-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/fedora38-ansible-latest/Dockerfile
 [docker-opensuse_tumbleweed-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/opensuse_tumbleweed-ansible-latest/Dockerfile
 [docker-arch-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/arch-ansible-latest/Dockerfile
@@ -79,6 +81,7 @@ Sebastian Gumprich <github@gumpri.ch>
 [rndmh3ro/docker-alpine-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-alpine-ansible
 [rndmh3ro/docker-amazon2-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-amazon2-ansible
 [rndmh3ro/docker-amazon2023-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-amazon2023-ansible
+[rndmh3ro/docker-fedora37-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-fedora37-ansible
 [rndmh3ro/docker-fedora38-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-fedora38-ansible
 [rndmh3ro/docker-opensuse_tumbleweed-ansible-latest]: https://hub.docker.com/repository/docker/rndmh3ro/docker-opensuse_tumbleweed-ansible
 [rndmh3ro/docker-arch-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-arch-ansible

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ They are meant for testing purposes and are mainly used for [dev-sec](https://gi
 | [Amazon Linux][amazon]            | [docker-amazon-ansible-latest][]              | [rndmh3ro/docker-amazon-ansible-latest][]              |
 | [Amazon Linux 2][amazon]          | [docker-amazon2-ansible-latest][]             | [rndmh3ro/docker-amazon2-ansible-latest][]             |
 | [Amazon Linux 2023][amazon]       | [docker-amazon2023-ansible-latest][]          | [rndmh3ro/docker-amazon2023-ansible-latest][]          |
-| [Fedora][fedora]                  | [docker-fedora-ansible-latest][]              | [rndmh3ro/docker-fedora-ansible-latest][]              |
+| [Fedora 38][fedora]               | [docker-fedora38-ansible-latest][]            | [rndmh3ro/docker-fedora38-ansible-latest][]            |
 | [OpenSuse Tumbleweed][tumbleweed] | [docker-opensuse_tumbleweed-ansible-latest][] | [rndmh3ro/docker-opensuse_tumbleweed-ansible-latest][] |
 | [Arch Linux][arch]                | [docker-arch-ansible-latest][]                | [rndmh3ro/docker-arch-ansible-latest][]                |
 | [OpenWRT][openwrt]                | [docker-openwrt-ansible-latest][]             | [rndmh3ro/docker-openwrt-ansible-latest][]             |
@@ -58,7 +58,7 @@ Sebastian Gumprich <github@gumpri.ch>
 [docker-alpine-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/alpine-ansible-latest/Dockerfile
 [docker-amazon2-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/amazon2-ansible-latest/Dockerfile
 [docker-amazon2023-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/amazon2023-ansible-latest/Dockerfile
-[docker-fedora-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/fedora-ansible-latest/Dockerfile
+[docker-fedora38-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/fedora38-ansible-latest/Dockerfile
 [docker-opensuse_tumbleweed-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/opensuse_tumbleweed-ansible-latest/Dockerfile
 [docker-arch-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/arch-ansible-latest/Dockerfile
 [docker-openwrt-ansible-latest]: https://github.com/rndmh3ro/docker-ansible/blob/master/openwrt-ansible-latest/Dockerfile
@@ -79,7 +79,7 @@ Sebastian Gumprich <github@gumpri.ch>
 [rndmh3ro/docker-alpine-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-alpine-ansible
 [rndmh3ro/docker-amazon2-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-amazon2-ansible
 [rndmh3ro/docker-amazon2023-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-amazon2023-ansible
-[rndmh3ro/docker-fedora-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-fedora-ansible
+[rndmh3ro/docker-fedora38-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-fedora38-ansible
 [rndmh3ro/docker-opensuse_tumbleweed-ansible-latest]: https://hub.docker.com/repository/docker/rndmh3ro/docker-opensuse_tumbleweed-ansible
 [rndmh3ro/docker-arch-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-arch-ansible
 [rndmh3ro/docker-openwrt-ansible-latest]: https://hub.docker.com/r/rndmh3ro/docker-openwrt-ansible

--- a/fedora37-ansible-latest/Dockerfile
+++ b/fedora37-ansible-latest/Dockerfile
@@ -1,0 +1,34 @@
+FROM fedora:37
+LABEL maintainer="Sebastian Gumprich"
+
+# Enable systemd.
+RUN dnf -y install systemd && dnf clean all && \
+  (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+  rm -f /lib/systemd/system/multi-user.target.wants/*;\
+  rm -f /etc/systemd/system/*.wants/*;\
+  rm -f /lib/systemd/system/local-fs.target.wants/*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+  rm -f /lib/systemd/system/basic.target.wants/*;\
+  rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN dnf -y update \
+    && dnf -y install ansible python python3-libselinux \
+    && dnf clean all
+
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+# https://molecule.readthedocs.io/en/latest/examples.html#docker-with-non-privileged-user
+# Create `ansible` user with sudo permissions and membership in `DEPLOY_GROUP`
+# This template gets rendered using `loop: "{{ molecule_yml.platforms }}"`, so
+# each `item` is an element of platforms list from the molecule.yml file for this scenario.
+ENV ANSIBLE_USER=ansible DEPLOY_GROUP=deployer SUDO_GROUP=wheel
+RUN set -xe \
+  && groupadd -r ${ANSIBLE_USER} \
+  && groupadd -r ${DEPLOY_GROUP} \
+  && useradd -m -g ${ANSIBLE_USER} ${ANSIBLE_USER} \
+  && usermod -aG ${SUDO_GROUP} ${ANSIBLE_USER} \
+  && usermod -aG ${DEPLOY_GROUP} ${ANSIBLE_USER} \
+  && sed -i "/^%${SUDO_GROUP}/s/ALL\$/NOPASSWD:ALL/g" /etc/sudoers
+
+CMD [ "ansible-playbook", "--version" ]

--- a/fedora37-ansible-latest/Dockerfile
+++ b/fedora37-ansible-latest/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:37
-LABEL maintainer="Sebastian Gumprich"
+LABEL maintainer="Sebastian Gumprich; Nejc Habjan; Diego Louzan; Max Wittig"
 
 # Enable systemd.
 RUN dnf -y install systemd && dnf clean all && \

--- a/fedora38-ansible-latest/Dockerfile
+++ b/fedora38-ansible-latest/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:38
-LABEL maintainer="Sebastian Gumprich"
+LABEL maintainer="Sebastian Gumprich, Nejc Habjan, Diego Louzan, Max Wittig"
 
 # Enable systemd.
 RUN dnf -y install systemd && dnf clean all && \

--- a/fedora38-ansible-latest/Dockerfile
+++ b/fedora38-ansible-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:38
 LABEL maintainer="Sebastian Gumprich"
 
 # Enable systemd.


### PR DESCRIPTION
Related to https://github.com/dev-sec/ansible-collection-hardening/issues/671, https://github.com/dev-sec/docker-ansible/issues/21.

fde891ff5122cf6fb7282d0a231bad5826eb30bb renames `latest` to an explicit 38 version.
7af061acb12e9f34e3ffbc3aa7900bc0e17ca8c5 brings back Fedora 37.
Currently a complete copy as AFAIK there are no changes needed from what I could see in the hardening repo.

This shouldn't be a breaking change as old tags of https://hub.docker.com/r/rndmh3ro/docker-fedora-ansible/tags will stay on Docker Hub.

/cc @rndmh3ro @dlouzan